### PR TITLE
[fix](bind decorator) bind should always return the same reference

### DIFF
--- a/src/core-wrappers.js
+++ b/src/core-wrappers.js
@@ -408,7 +408,7 @@ var decoratorWrapper = {
     }
 
     descriptor.get = function(){
-      return bind(this, fn);
+      return this.__boundFn__ || (this.__boundFn__ = bind(this, fn));
     }
 
     return descriptor;

--- a/src/core-wrappers.js
+++ b/src/core-wrappers.js
@@ -397,8 +397,10 @@ function toDecorator(wrapper){
 
 var decoratorWrapper = {
   bind: function(fn){
-    var target = this.target, key = this.key, 
-        descriptor = this.descriptor;
+    var target = this.target, key = this.key,
+        descriptor = this.descriptor,
+        // use function name(or fn string if not support Function.name) as identifier which can ensure every function uniquely after wrapped
+        fnName = '__' + (fn.name || fn) + 'Fn';
 
     delete descriptor.value;
     delete descriptor.writable;
@@ -409,7 +411,7 @@ var decoratorWrapper = {
 
     descriptor.get = function(){
       // use fn reference as identifier which can ensure every function uniquely after wrapped
-      return this[fn] || (this[fn] = bind(this, fn));
+      return this[fnName] || (this[fnName] = bind(this, fn));
     }
 
     return descriptor;

--- a/src/core-wrappers.js
+++ b/src/core-wrappers.js
@@ -408,7 +408,8 @@ var decoratorWrapper = {
     }
 
     descriptor.get = function(){
-      return this.__boundFn__ || (this.__boundFn__ = bind(this, fn));
+      // use fn reference as identifier which can ensure every function uniquely after wrapped
+      return this[fn] || (this[fn] = bind(this, fn));
     }
 
     return descriptor;

--- a/test/wrapperSpec.js
+++ b/test/wrapperSpec.js
@@ -289,6 +289,8 @@ describe('Core Wrappers', function(){
       }
       var foo = new Foo();
       var bar = foo.bar;
+      var bar1 = foo.bar;
+      expect(bar).to.equal(bar1);
       expect(bar()).to.equal(1);
     });
 


### PR DESCRIPTION
I think the bind decorator should always return the same reference.
for example:

``` js
class Popup{

    @bind
    _resize(){
        // something
    }

    open(){
        window.addEventListener('resize', this._resize);
    }

    close(){
        window.removeEventListener('resize', this._resize);
    }
}
```

Now it always create a new reference due to the `Function.prototype.bind` method which will make the event unbind incorrectly.
see my additional test code,u will understand what I say.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/akira-cn/core-wrappers/1)

<!-- Reviewable:end -->
