### PR TITLE
[fix](bind decorator) reset method of instance would cause stack over flow exception

### DIFF
--- a/src/core-wrappers.js
+++ b/src/core-wrappers.js
@@ -397,8 +397,7 @@ function toDecorator(wrapper){
 
 var decoratorWrapper = {
   bind: function(fn){
-    var target = this.target, key = this.key,
-        descriptor = this.descriptor,
+    var descriptor = this.descriptor,
         // use function name(or fn string if not support Function.name) as identifier which can ensure every function uniquely after wrapped
         fnName = '__' + (fn.name || fn) + 'Fn';
 
@@ -406,7 +405,7 @@ var decoratorWrapper = {
     delete descriptor.writable;
 
     descriptor.set = function(value){
-      target[key] = value;
+      this[fnName] = value;
     }
 
     descriptor.get = function(){

--- a/test/wrapperSpec.js
+++ b/test/wrapperSpec.js
@@ -292,6 +292,13 @@ describe('Core Wrappers', function(){
       var bar1 = foo.bar;
       expect(bar).to.equal(bar1);
       expect(bar()).to.equal(1);
+      
+      var originalBar = foo.bar;
+      foo.bar = function () {
+        return originalBar();
+      };
+      var bar2 = foo.bar;
+      expect(bar2()).to.equal(1);
     });
 
     it('debounce', function(done){


### PR DESCRIPTION
reset method of instance would cause stack over flow exception which had decorated with bind

here is the essential reason

``` js
descriptor.set = function(value){
      target[key] = value;
}
```

`target[key]` represent itself and  reassign it will invoke the setter again and again.see my test case.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/akira-cn/core-wrappers/2)

<!-- Reviewable:end -->
