### PR TITLE
[fix](bind decorator) can not use Function.name as identifier

### DIFF
--- a/src/core-wrappers.js
+++ b/src/core-wrappers.js
@@ -398,8 +398,9 @@ function toDecorator(wrapper){
 var decoratorWrapper = {
   bind: function(fn){
     var descriptor = this.descriptor,
-        // use function name(or fn string if not support Function.name) as identifier which can ensure every function uniquely after wrapped
-        fnName = '__' + (fn.name || fn) + 'Fn';
+        // use function string as identifier which can ensure every function uniquely after wrapped
+        // we can not use Function.name as identifier because its name may be empty(anonymous function) or defined by other ways(such as Object.defineProperty)
+        fnName = '__' + fn + 'Fn__';
 
     delete descriptor.value;
     delete descriptor.writable;

--- a/test/wrapperSpec.js
+++ b/test/wrapperSpec.js
@@ -299,6 +299,35 @@ describe('Core Wrappers', function(){
       };
       var bar2 = foo.bar;
       expect(bar2()).to.equal(1);
+      
+      // test non-decorator used
+      class Klass {}
+      const descriptors = [
+        {
+          key: 'fn1',
+          value: function() {
+            return 1;
+          }
+        },
+        {
+          key: 'fn2',
+          value: function() {
+            return 2;
+          }
+        }
+      ];
+
+      descriptors.forEach(descriptor => {
+        const target = Klass.prototype;
+        const name = descriptor.key;
+        Object.defineProperty(target, name, bind(target, name, descriptor));
+      });
+
+      const instance = new Klass();
+
+      expect(instance.fn1).not.equal(instance.fn2);
+      expect(instance.fn1()).to.equal(1);
+      expect(instance.fn2()).to.equal(2);
     });
 
     it('debounce', function(done){


### PR DESCRIPTION
hi,here I come again😂
In bind decorator we can not use Function.name as identifier because its name may be empty(anonymous function) or defined by other ways(such as Object.defineProperty, mostly compiled by webpack).

``` js
Object.defineProperty(Constructor.prototype, name, bind(target, name, {
    value: function() {}
}));
```

if all my methods of Class are defined by this way, there Function.name would be the same which equal 'value' string.

see my test case.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/akira-cn/core-wrappers/3)

<!-- Reviewable:end -->
